### PR TITLE
BoilerplateAppStaticStorage fixed according to django 1.7 changes

### DIFF
--- a/aldryn_boilerplates/staticfile_finders.py
+++ b/aldryn_boilerplates/staticfile_finders.py
@@ -11,7 +11,7 @@ def _get_boilerplate_source_dir(boilerplate_name):
     return 'boilerplates/{0}/static'.format(settings.ALDRYN_BOILERPLATE_NAME)
 
 
-class BoilerplateAppStaticStorage(django.contrib.staticfiles.storage.AppStaticStorage):
+class BoilerplateAppStaticStorage(django.contrib.staticfiles.storage.FileSystemStorage):
     """
     A file system storage backend that takes an app module and works
     for the ``boilerplates/<my-boilerplate-name>/static`` directory inside the app.


### PR DESCRIPTION
Suddenly AppStaticStorage was removed from Django: https://github.com/django/django/commit/f56c88a8eed91f68f6845bbf730f7b7361c5cfb1
Fortunately the fix is quite simple.
